### PR TITLE
Build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,10 +49,7 @@ jobs:
       with:
         name: build-artifacts
         path: |
-          common/build/libs/*.jar
           plugin/build/libs/*.jar
-          postgres/build/libs/*.jar
-          s3/build/libs/*.jar
 
     - name: Set Release Name
       id: set_release_name

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         echo "version=$VERSION" >> $GITHUB_OUTPUT
 
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew build -x
 
     - name: List all JAR files
       run: find . -name "*.jar" -type f -not -path "*/build/tmp/*" -not -path "*/run/*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,77 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      release_name:
+        description: 'Release name'
+        required: false
+        default: 'Manual Release'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up JDK 23
+      uses: actions/setup-java@v3
+      with:
+        java-version: '23'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Get Project Version
+      id: get_version
+      run: |
+        VERSION=$(./gradlew properties | grep "version:" | awk '{print $2}')
+        echo "Project version: $VERSION"
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+    - name: Build with Gradle
+      run: ./gradlew build
+
+    - name: List all JAR files
+      run: find . -name "*.jar" -type f -not -path "*/build/tmp/*" -not -path "*/run/*"
+
+    - name: Upload Build Artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: build-artifacts
+        path: |
+          common/build/libs/*.jar
+          plugin/build/libs/*.jar
+          postgres/build/libs/*.jar
+          s3/build/libs/*.jar
+
+    - name: Set Release Name
+      id: set_release_name
+      run: |
+        if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          echo "release_name=${{ github.event.inputs.release_name }} (v${{ steps.get_version.outputs.version }})" >> $GITHUB_OUTPUT
+        else
+          echo "release_name=Release ${{ github.ref_name }} (v${{ steps.get_version.outputs.version }})" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Create Release
+      id: create_release
+      uses: softprops/action-gh-release@v1
+      with:
+        name: ${{ steps.set_release_name.outputs.release_name }}
+        draft: false
+        prerelease: false
+        files: |
+          common/build/libs/*.jar
+          plugin/build/libs/*.jar
+          postgres/build/libs/*.jar
+          s3/build/libs/*.jar
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - name: Checkout code
@@ -37,7 +39,7 @@ jobs:
         echo "version=$VERSION" >> $GITHUB_OUTPUT
 
     - name: Build with Gradle
-      run: ./gradlew build -x test
+      run: ./gradlew build
 
     - name: List all JAR files
       run: find . -name "*.jar" -type f -not -path "*/build/tmp/*" -not -path "*/run/*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up JDK 23
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '23'
         distribution: 'temurin'
@@ -43,7 +43,7 @@ jobs:
       run: find . -name "*.jar" -type f -not -path "*/build/tmp/*" -not -path "*/run/*"
 
     - name: Upload Build Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: build-artifacts
         path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         echo "version=$VERSION" >> $GITHUB_OUTPUT
 
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew build -x test
 
     - name: List all JAR files
       run: find . -name "*.jar" -type f -not -path "*/build/tmp/*" -not -path "*/run/*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         echo "version=$VERSION" >> $GITHUB_OUTPUT
 
     - name: Build with Gradle
-      run: ./gradlew build -x
+      run: ./gradlew build -x test --no-daemon --stacktrace
 
     - name: List all JAR files
       run: find . -name "*.jar" -type f -not -path "*/build/tmp/*" -not -path "*/run/*"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the build and release process for the project. The workflow supports both manual and tag-based releases, sets up the necessary environment for building the project, and handles artifact uploads and release creation.

### Build and Release Automation:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R1-R76): Added a new workflow named "Build and Release" that triggers on tag pushes (`v*`) or manual dispatch. It sets up JDK 23, builds the project using Gradle, uploads JAR files as build artifacts, and creates a GitHub release with the generated artifacts.