### PR TITLE
Cache markers

### DIFF
--- a/common/src/main/java/org/readutf/buildformat/common/Build.java
+++ b/common/src/main/java/org/readutf/buildformat/common/Build.java
@@ -1,11 +1,11 @@
 package org.readutf.buildformat.common;
 
 import org.readutf.buildformat.common.meta.BuildMeta;
-import org.readutf.buildformat.common.schematic.BuildSchematic;
+import org.readutf.buildformat.common.schematic.BuildData;
 
 public record Build(
     BuildMeta buildMeta,
-    BuildSchematic buildSchematic
+    BuildData buildData
 ) {
 
 }

--- a/common/src/main/java/org/readutf/buildformat/common/BuildManager.java
+++ b/common/src/main/java/org/readutf/buildformat/common/BuildManager.java
@@ -8,7 +8,7 @@ import org.readutf.buildformat.common.exception.BuildFormatException;
 import org.readutf.buildformat.common.format.BuildFormatChecksum;
 import org.readutf.buildformat.common.meta.BuildMeta;
 import org.readutf.buildformat.common.meta.BuildMetaStore;
-import org.readutf.buildformat.common.schematic.BuildSchematic;
+import org.readutf.buildformat.common.schematic.BuildData;
 import org.readutf.buildformat.common.schematic.BuildSchematicStore;
 
 public class BuildManager {
@@ -27,7 +27,7 @@ public class BuildManager {
         BuildMeta meta = buildMetaStore.getByName(name);
         if (meta == null) return null;
 
-        BuildSchematic buildData = schematicStore.load(name);
+        BuildData buildData = schematicStore.load(name);
         if (buildData == null) return null;
         return new Build(meta, buildData);
     }

--- a/common/src/main/java/org/readutf/buildformat/common/meta/BuildMeta.java
+++ b/common/src/main/java/org/readutf/buildformat/common/meta/BuildMeta.java
@@ -6,7 +6,6 @@ import org.readutf.buildformat.common.format.BuildFormatChecksum;
 public record BuildMeta(
         String name,
         String description,
-        int version,
         List<String> tags,
         List<BuildFormatChecksum> formats
 ) {

--- a/common/src/main/java/org/readutf/buildformat/common/meta/BuildMetaStore.java
+++ b/common/src/main/java/org/readutf/buildformat/common/meta/BuildMetaStore.java
@@ -13,7 +13,7 @@ public interface BuildMetaStore {
 
     @Nullable BuildMeta getByName(@NotNull String name) throws BuildFormatException;
 
-    BuildMeta update(@NotNull String name, @NotNull List<BuildFormatChecksum> formats) throws BuildFormatException;
+    void update(@NotNull String name, @NotNull List<BuildFormatChecksum> formats) throws BuildFormatException;
 
     @NotNull List<String> getBuilds() throws BuildFormatException;
 

--- a/common/src/main/java/org/readutf/buildformat/common/meta/impl/InMemoryMetaStore.java
+++ b/common/src/main/java/org/readutf/buildformat/common/meta/impl/InMemoryMetaStore.java
@@ -19,7 +19,7 @@ public class InMemoryMetaStore implements BuildMetaStore {
         if(buildMetas.containsKey(name)) {
             throw new BuildFormatException("Build with name " + name + " already exists");
         }
-        BuildMeta buildMeta = new BuildMeta(name, description, 1, List.of(), List.of());
+        BuildMeta buildMeta = new BuildMeta(name, description, List.of(), List.of());
         buildMetas.put(name, buildMeta);
         return buildMeta;
     }
@@ -30,7 +30,7 @@ public class InMemoryMetaStore implements BuildMetaStore {
     }
 
     @Override
-    public BuildMeta update(@NotNull String name, @NotNull List<BuildFormatChecksum> formats) throws BuildFormatException {
+    public void update(@NotNull String name, @NotNull List<BuildFormatChecksum> formats) throws BuildFormatException {
         BuildMeta buildMeta = buildMetas.get(name);
         if (buildMeta == null) {
             throw new BuildFormatException("Build with name " + name + " does not exist");
@@ -38,12 +38,10 @@ public class InMemoryMetaStore implements BuildMetaStore {
         BuildMeta updated = new BuildMeta(
                 buildMeta.name(),
                 buildMeta.description(),
-                1,
                 buildMeta.tags(),
                 formats
         );
         buildMetas.put(name, updated);
-        return buildMeta;
     }
 
     @Override

--- a/common/src/main/java/org/readutf/buildformat/common/schematic/BuildData.java
+++ b/common/src/main/java/org/readutf/buildformat/common/schematic/BuildData.java
@@ -1,0 +1,4 @@
+package org.readutf.buildformat.common.schematic;
+
+public record BuildData(String buildName, byte[] buildData) {
+}

--- a/common/src/main/java/org/readutf/buildformat/common/schematic/BuildData.java
+++ b/common/src/main/java/org/readutf/buildformat/common/schematic/BuildData.java
@@ -1,4 +1,8 @@
 package org.readutf.buildformat.common.schematic;
 
-public record BuildData(String buildName, byte[] buildData) {
+import org.readutf.buildformat.common.markers.Marker;
+
+import java.util.List;
+
+public record BuildData(String buildName, List<Marker> markers, byte[] buildData) {
 }

--- a/common/src/main/java/org/readutf/buildformat/common/schematic/BuildSchematic.java
+++ b/common/src/main/java/org/readutf/buildformat/common/schematic/BuildSchematic.java
@@ -1,4 +1,0 @@
-package org.readutf.buildformat.common.schematic;
-
-public record BuildSchematic(String buildName, byte[] buildData) {
-}

--- a/common/src/main/java/org/readutf/buildformat/common/schematic/BuildSchematicStore.java
+++ b/common/src/main/java/org/readutf/buildformat/common/schematic/BuildSchematicStore.java
@@ -5,7 +5,7 @@ import org.readutf.buildformat.common.exception.BuildFormatException;
 
 public interface BuildSchematicStore {
 
-    void save(BuildSchematic buildSchematic) throws BuildFormatException;
+    void save(BuildData buildData) throws BuildFormatException;
 
     /**
      * Load the latest version of the build schematic
@@ -13,7 +13,7 @@ public interface BuildSchematicStore {
      * @return the schematic data
      * @throws BuildFormatException - if the schematic is not found or cannot be loaded
      */
-    BuildSchematic load(String name) throws BuildFormatException;
+    BuildData load(String name) throws BuildFormatException;
 
     List<String> history(String name) throws BuildFormatException;
 

--- a/plugin/src/main/java/org/readutf/buildformat/plugin/commands/BuildCommand.java
+++ b/plugin/src/main/java/org/readutf/buildformat/plugin/commands/BuildCommand.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.stream.Stream;
@@ -35,11 +34,10 @@ import org.readutf.buildformat.common.exception.BuildFormatException;
 import org.readutf.buildformat.common.format.BuildFormatChecksum;
 import org.readutf.buildformat.common.format.BuildFormatManager;
 import org.readutf.buildformat.common.format.CompiledBuildFormat;
-import org.readutf.buildformat.common.format.requirements.RequirementData;
 import org.readutf.buildformat.common.markers.Marker;
 import org.readutf.buildformat.common.meta.BuildMeta;
 import org.readutf.buildformat.common.meta.BuildMetaStore;
-import org.readutf.buildformat.common.schematic.BuildSchematic;
+import org.readutf.buildformat.common.schematic.BuildData;
 import org.readutf.buildformat.common.schematic.BuildSchematicStore;
 import org.readutf.buildformat.plugin.commands.types.BuildType;
 import org.readutf.buildformat.plugin.formats.BuildFormatStore;
@@ -182,7 +180,7 @@ public class BuildCommand {
         player.sendMessage(Component.text("Uploading build file..."));
 
         try {
-            buildSchematicStore.save(new BuildSchematic(name, data));
+            buildSchematicStore.save(new BuildData(name, data));
             player.sendMessage(Component.text("Updating database...").color(NamedTextColor.GREEN));
             buildMetaStore.update(name, checksums);
             player.sendMessage(Component.text("Build " + name + " saved with formats: " + formatNames).color(NamedTextColor.GREEN));

--- a/plugin/src/main/java/org/readutf/buildformat/plugin/commands/BuildCommand.java
+++ b/plugin/src/main/java/org/readutf/buildformat/plugin/commands/BuildCommand.java
@@ -180,7 +180,7 @@ public class BuildCommand {
         player.sendMessage(Component.text("Uploading build file..."));
 
         try {
-            buildSchematicStore.save(new BuildData(name, data));
+            buildSchematicStore.save(new BuildData(name, List.of(), data));
             player.sendMessage(Component.text("Updating database...").color(NamedTextColor.GREEN));
             buildMetaStore.update(name, checksums);
             player.sendMessage(Component.text("Build " + name + " saved with formats: " + formatNames).color(NamedTextColor.GREEN));

--- a/s3/build.gradle.kts
+++ b/s3/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     testImplementation("org.testcontainers:localstack:1.21.3")
 
     implementation(project(":common"))
+    implementation("tools.jackson.core:jackson-databind:3.0.0")
 
     api("software.amazon.awssdk:aws-core:2.31.77")
     api("software.amazon.awssdk:s3:2.31.77")

--- a/s3/build.gradle.kts
+++ b/s3/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     testImplementation("org.testcontainers:localstack:1.21.3")
 
     implementation(project(":common"))
-    implementation("tools.jackson.core:jackson-databind:3.0.0")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.20.0")
 
     api("software.amazon.awssdk:aws-core:2.31.77")
     api("software.amazon.awssdk:s3:2.31.77")

--- a/s3/src/main/java/org/readutf/buildformat/s3/S3BuildSchematicStore.java
+++ b/s3/src/main/java/org/readutf/buildformat/s3/S3BuildSchematicStore.java
@@ -6,6 +6,7 @@ import java.util.concurrent.CompletableFuture;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.readutf.buildformat.common.exception.BuildFormatException;
+import org.readutf.buildformat.common.markers.Marker;
 import org.readutf.buildformat.common.schematic.BuildData;
 import org.readutf.buildformat.common.schematic.BuildSchematicStore;
 import org.slf4j.Logger;
@@ -18,13 +19,18 @@ import software.amazon.awssdk.services.s3.model.*;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
 import software.amazon.awssdk.transfer.s3.model.*;
 import software.amazon.awssdk.transfer.s3.progress.LoggingTransferListener;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 public class S3BuildSchematicStore implements BuildSchematicStore {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(S3BuildSchematicStore.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    private @NotNull final S3TransferManager transferManager;
-    private @NotNull final String bucketName;
+    private @NotNull
+    final S3TransferManager transferManager;
+    private @NotNull
+    final String bucketName;
 
     public S3BuildSchematicStore(@NotNull S3AsyncClient s3Client, @NotNull String bucketName) {
         this.transferManager = S3TransferManager.builder().s3Client(s3Client).build();
@@ -32,7 +38,7 @@ public class S3BuildSchematicStore implements BuildSchematicStore {
     }
 
     @Override
-    public void save(BuildData buildSchematic) throws BuildFormatException {
+    public void save(@NotNull BuildData buildSchematic) throws BuildFormatException {
 
         // Ensure its alphanumeric with underscores and dashes
         if (!buildSchematic.buildName().matches("^[a-zA-Z0-9_-]+$")) {
@@ -41,18 +47,29 @@ public class S3BuildSchematicStore implements BuildSchematicStore {
 
         // Create body
         byte[] buildData = buildSchematic.buildData();
+        byte[] markersJsonData = MAPPER.writeValueAsBytes(buildSchematic.markers());
 
-        UploadRequest uploadRequest = UploadRequest.builder()
+        UploadRequest schematicUploadRequest = UploadRequest.builder()
                 .putObjectRequest(
-                        builder -> builder.bucket(bucketName).key("%s.schem".formatted(buildSchematic.buildName())))
+                        builder -> builder.bucket(bucketName).key("%s/build.schem".formatted(buildSchematic.buildName())))
                 .addTransferListener(LoggingTransferListener.create())
                 .requestBody(AsyncRequestBody.fromBytes(buildData))
                 .build();
 
+        UploadRequest markersUploadRequest = UploadRequest.builder()
+                .putObjectRequest(
+                        builder -> builder.bucket(bucketName).key("%s/markers.json".formatted(buildSchematic.buildName()))
+                ).addTransferListener(LoggingTransferListener.create())
+                .requestBody(AsyncRequestBody.fromBytes(markersJsonData))
+                .build();
+
         try {
-            CompletableFuture<CompletedUpload> future =
-                    transferManager.upload(uploadRequest).completionFuture();
-            future.join();
+            CompletableFuture<CompletedUpload> schematicUploadFuture =
+                    transferManager.upload(schematicUploadRequest).completionFuture();
+            CompletableFuture<CompletedUpload> markersUploadFuture =
+                    transferManager.upload(markersUploadRequest).completionFuture();
+
+            CompletableFuture.allOf(schematicUploadFuture, markersUploadFuture).join();
         } catch (Exception e) {
             throw new BuildFormatException("Failed to save build schematic to S3", e);
         }
@@ -61,27 +78,39 @@ public class S3BuildSchematicStore implements BuildSchematicStore {
     }
 
     @Override
-    public @Nullable BuildData load(String name) throws BuildFormatException {
+    public @Nullable BuildData load(@NotNull String name) throws BuildFormatException {
         // Ensure its alphanumeric with underscores and dashes
         if (!name.matches("^[a-zA-Z0-9_-]+$")) {
             throw new BuildFormatException("Build name must be alphanumeric + dashes and underscores");
         }
 
-        DownloadRequest<ResponseBytes<GetObjectResponse>> downloadRequest = DownloadRequest.builder()
+        DownloadRequest<ResponseBytes<GetObjectResponse>> schematicDownloadRequest = DownloadRequest.builder()
                 .getObjectRequest(req -> req.bucket(bucketName).key("%s.schem".formatted(name)))
                 .responseTransformer(AsyncResponseTransformer.toBytes())
                 .build();
 
-        CompletedDownload<ResponseBytes<GetObjectResponse>> downloaded =
-                transferManager.download(downloadRequest).completionFuture().join();
+        CompletedDownload<ResponseBytes<GetObjectResponse>> schematicDownload =
+                transferManager.download(schematicDownloadRequest).completionFuture().join();
 
-        byte[] byteArray = downloaded.result().asByteArray();
+        DownloadRequest<ResponseBytes<GetObjectResponse>> markersDownloadRequest = DownloadRequest.builder()
+                .getObjectRequest(req -> req.bucket(bucketName).key("%s.schem".formatted(name)))
+                .responseTransformer(AsyncResponseTransformer.toBytes())
+                .build();
 
-        return new BuildData(name, List.of(), byteArray);
+        CompletedDownload<ResponseBytes<GetObjectResponse>> markersDownload =
+                transferManager.download(markersDownloadRequest).completionFuture().join();
+
+        byte[] schematicData = schematicDownload.result().asByteArray();
+        byte[] markersData = markersDownload.result().asByteArray();
+
+        List<Marker> markers = MAPPER.readValue(markersData, new TypeReference<>() {
+        });
+
+        return new BuildData(name, markers, schematicData);
     }
 
     @Override
-    public List<String> history(String name) throws BuildFormatException {
+    public List<String> history(String name) {
 
         return List.of();
     }

--- a/s3/src/main/java/org/readutf/buildformat/s3/S3BuildSchematicStore.java
+++ b/s3/src/main/java/org/readutf/buildformat/s3/S3BuildSchematicStore.java
@@ -77,7 +77,7 @@ public class S3BuildSchematicStore implements BuildSchematicStore {
 
         byte[] byteArray = downloaded.result().asByteArray();
 
-        return new BuildData(name, byteArray);
+        return new BuildData(name, List.of(), byteArray);
     }
 
     @Override

--- a/s3/src/main/java/org/readutf/buildformat/s3/S3BuildSchematicStore.java
+++ b/s3/src/main/java/org/readutf/buildformat/s3/S3BuildSchematicStore.java
@@ -6,7 +6,7 @@ import java.util.concurrent.CompletableFuture;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.readutf.buildformat.common.exception.BuildFormatException;
-import org.readutf.buildformat.common.schematic.BuildSchematic;
+import org.readutf.buildformat.common.schematic.BuildData;
 import org.readutf.buildformat.common.schematic.BuildSchematicStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,7 +32,7 @@ public class S3BuildSchematicStore implements BuildSchematicStore {
     }
 
     @Override
-    public void save(BuildSchematic buildSchematic) throws BuildFormatException {
+    public void save(BuildData buildSchematic) throws BuildFormatException {
 
         // Ensure its alphanumeric with underscores and dashes
         if (!buildSchematic.buildName().matches("^[a-zA-Z0-9_-]+$")) {
@@ -61,7 +61,7 @@ public class S3BuildSchematicStore implements BuildSchematicStore {
     }
 
     @Override
-    public @Nullable BuildSchematic load(String name) throws BuildFormatException {
+    public @Nullable BuildData load(String name) throws BuildFormatException {
         // Ensure its alphanumeric with underscores and dashes
         if (!name.matches("^[a-zA-Z0-9_-]+$")) {
             throw new BuildFormatException("Build name must be alphanumeric + dashes and underscores");
@@ -77,7 +77,7 @@ public class S3BuildSchematicStore implements BuildSchematicStore {
 
         byte[] byteArray = downloaded.result().asByteArray();
 
-        return new BuildSchematic(name, byteArray);
+        return new BuildData(name, byteArray);
     }
 
     @Override

--- a/s3/src/test/java/org/readutf/buildformat/s3/S3BuildDataStoreTest.java
+++ b/s3/src/test/java/org/readutf/buildformat/s3/S3BuildDataStoreTest.java
@@ -17,6 +17,7 @@ import software.amazon.awssdk.services.s3.model.CreateBucketResponse;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 class S3BuildDataStoreTest {
 
@@ -50,7 +51,7 @@ class S3BuildDataStoreTest {
 
         // Load Atlantis.schem from resources
         BuildData schematic = new BuildData(
-                "Atlantis", Files.readAllBytes(Path.of("src", "test", "resources", "Atlantis.schem")));
+                "Atlantis", List.of(), Files.readAllBytes(Path.of("src", "test", "resources", "Atlantis.schem")));
 
         store.save(schematic);
 
@@ -81,7 +82,7 @@ class S3BuildDataStoreTest {
 
         // Load Atlantis.schem from resources
         BuildData schematic = new BuildData(
-                "Atlantis", Files.readAllBytes(Path.of("src", "test", "resources", "Atlantis.schem")));
+                "Atlantis", List.of(), Files.readAllBytes(Path.of("src", "test", "resources", "Atlantis.schem")));
 
         store.save(schematic);
 

--- a/s3/src/test/java/org/readutf/buildformat/s3/S3BuildDataStoreTest.java
+++ b/s3/src/test/java/org/readutf/buildformat/s3/S3BuildDataStoreTest.java
@@ -3,7 +3,7 @@ package org.readutf.buildformat.s3;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.readutf.buildformat.common.exception.BuildFormatException;
-import org.readutf.buildformat.common.schematic.BuildSchematic;
+import org.readutf.buildformat.common.schematic.BuildData;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -18,7 +18,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-class S3BuildSchematicStoreTest {
+class S3BuildDataStoreTest {
 
     @BeforeAll
     public static void beforeAll() {}
@@ -49,12 +49,12 @@ class S3BuildSchematicStoreTest {
         S3BuildSchematicStore store = new S3BuildSchematicStore(s3, "test");
 
         // Load Atlantis.schem from resources
-        BuildSchematic schematic = new BuildSchematic(
+        BuildData schematic = new BuildData(
                 "Atlantis", Files.readAllBytes(Path.of("src", "test", "resources", "Atlantis.schem")));
 
         store.save(schematic);
 
-        BuildSchematic downloaded = store.load("Atlantis");
+        BuildData downloaded = store.load("Atlantis");
 
         System.out.println(downloaded);
     }
@@ -80,12 +80,12 @@ class S3BuildSchematicStoreTest {
         S3BuildSchematicStore store = new S3BuildSchematicStore(client, bucket);
 
         // Load Atlantis.schem from resources
-        BuildSchematic schematic = new BuildSchematic(
+        BuildData schematic = new BuildData(
                 "Atlantis", Files.readAllBytes(Path.of("src", "test", "resources", "Atlantis.schem")));
 
         store.save(schematic);
 
-        BuildSchematic downloaded = store.load("Atlantis");
+        BuildData downloaded = store.load("Atlantis");
 
         System.out.println(downloaded);
     }

--- a/sql/src/main/kotlin/org/readutf/buildformat/sql/ExposedMetaStore.kt
+++ b/sql/src/main/kotlin/org/readutf/buildformat/sql/ExposedMetaStore.kt
@@ -103,7 +103,7 @@ open class ExposedMetaStore private constructor(
     override fun update(
         name: String,
         formats: List<BuildFormatChecksum?>
-    ): BuildMeta? {
+    ) {
         return transaction(database) {
             val buildMetaRow = Tables.BuildMeta
                 .selectAll()
@@ -121,7 +121,6 @@ open class ExposedMetaStore private constructor(
                 }
             }
 
-            getByName(name)
         }
     }
 

--- a/sql/src/main/kotlin/org/readutf/buildformat/sql/ExposedMetaStore.kt
+++ b/sql/src/main/kotlin/org/readutf/buildformat/sql/ExposedMetaStore.kt
@@ -44,7 +44,6 @@ open class ExposedMetaStore private constructor(
             transaction(database) {
                 Tables.BuildMeta.insert {
                     it[this.name] = name
-                    it[this.version] = 1
                     it[this.description] = description
                 }
             }
@@ -58,7 +57,6 @@ open class ExposedMetaStore private constructor(
         return BuildMeta(
             name,
             description,
-            1,
             emptyList(),
             emptyList()
         )
@@ -95,7 +93,6 @@ open class ExposedMetaStore private constructor(
                 BuildMeta(
                     buildMetaRow[Tables.BuildMeta.name],
                     buildMetaRow[Tables.BuildMeta.description],
-                    buildMetaRow[Tables.BuildMeta.version],
                     tags,
                     checksums
                 )
@@ -114,14 +111,7 @@ open class ExposedMetaStore private constructor(
                 .singleOrNull() ?: throw BuildFormatException("Could not find build meta with name $name")
 
             val id = buildMetaRow[Tables.BuildMeta.id]
-
             Tables.BuildMetaFormat.deleteWhere { Tables.BuildMetaFormat.buildMeta eq id }
-
-            Tables.BuildMeta.update({ Tables.BuildMeta.name eq name }) {
-                it[version] = buildMetaRow[Tables.BuildMeta.version] + 1
-            }
-
-            val newVersion = buildMetaRow[Tables.BuildMeta.version] + 1
 
             formats.filterNotNull().forEach { format ->
                 Tables.BuildMetaFormat.insert {

--- a/sql/src/main/kotlin/org/readutf/buildformat/sql/Tables.kt
+++ b/sql/src/main/kotlin/org/readutf/buildformat/sql/Tables.kt
@@ -6,7 +6,6 @@ import org.jetbrains.exposed.dao.id.IntIdTable
 object Tables {
     object BuildMeta : IntIdTable("buildmeta") {
         val name = varchar("name", 32).uniqueIndex("UK_build_meta_name")
-        val version = integer("version")
         val description = varchar("description", 128)
     }
 


### PR DESCRIPTION
This pull request refactors the build schematic data model and its storage logic across the codebase. The main changes include replacing the old `BuildSchematic` class with a new, more extensible `BuildData` class, updating all related interfaces and implementations, and improving S3 storage to handle markers as a separate JSON file. Additionally, the `version` field was removed from `BuildMeta`, and the update method in `BuildMetaStore` was changed to return void. These changes improve extensibility and data handling for builds.

### Data Model Refactoring

* Replaced the `BuildSchematic` class with a new `BuildData` record, which includes support for markers and better encapsulates build data. All references and usages throughout the codebase have been updated to use `BuildData` instead of `BuildSchematic`. (`common/src/main/java/org/readutf/buildformat/common/Build.java`, `common/src/main/java/org/readutf/buildformat/common/schematic/BuildData.java`, `common/src/main/java/org/readutf/buildformat/common/schematic/BuildSchematic.java`, [[1]](diffhunk://#diff-5bea9c1732c0eebb55f1cbe02cec381e22b7bb22185c78b594630272294b7243R1-R8) [[2]](diffhunk://#diff-c578b8d14b960015e095fa436799fa2270144fa58a831166170c2b8224ad9eb7L1-L4) [[3]](diffhunk://#diff-f75cf7994c2587f4d96559ba388093bc5513bdc4461245458f4dcc2a1040ee7dL4-R8) [[4]](diffhunk://#diff-4018f9529743360fcc16234830c14c6f3c171cafcbd900aabcbcf887019a6bfaL11-R11) [[5]](diffhunk://#diff-4018f9529743360fcc16234830c14c6f3c171cafcbd900aabcbcf887019a6bfaL30-R30) [[6]](diffhunk://#diff-7b540a1bcca72fedab6501a14d7b37aac4f6e92c24202dc7209cc05e18afb677L8-R16) [[7]](diffhunk://#diff-9cf800743ae1dfad6d3cdef278c6cce119f22025ad9eede00a0c092457e0c7c6L38-R40) [[8]](diffhunk://#diff-9cf800743ae1dfad6d3cdef278c6cce119f22025ad9eede00a0c092457e0c7c6L185-R183) [[9]](diffhunk://#diff-68c0eba203b38c0257ffc09dcdaa0256c6b75c6cb90ce7ee7e34961937537fbcR3-R15) [[10]](diffhunk://#diff-68c0eba203b38c0257ffc09dcdaa0256c6b75c6cb90ce7ee7e34961937537fbcR31-R76) [[11]](diffhunk://#diff-68c0eba203b38c0257ffc09dcdaa0256c6b75c6cb90ce7ee7e34961937537fbcL64-R121) [[12]](diffhunk://#diff-9d2d089425c8ccc178581ed0adfcd4e7a18998a47a43fa9dec81193e9b08d5a3L6-R6) [[13]](diffhunk://#diff-9d2d089425c8ccc178581ed0adfcd4e7a18998a47a43fa9dec81193e9b08d5a3R20-R22) [[14]](diffhunk://#diff-9d2d089425c8ccc178581ed0adfcd4e7a18998a47a43fa9dec81193e9b08d5a3L52-R58) [[15]](diffhunk://#diff-9d2d089425c8ccc178581ed0adfcd4e7a18998a47a43fa9dec81193e9b08d5a3L83-R89)

### S3 Storage Improvements

* Updated the S3 build storage implementation to save and load build markers as a separate JSON file alongside the schematic data, using Jackson for serialization/deserialization. This allows for richer metadata and extensibility. (`s3/src/main/java/org/readutf/buildformat/s3/S3BuildSchematicStore.java`, `s3/build.gradle.kts`, [[1]](diffhunk://#diff-68c0eba203b38c0257ffc09dcdaa0256c6b75c6cb90ce7ee7e34961937537fbcR3-R15) [[2]](diffhunk://#diff-68c0eba203b38c0257ffc09dcdaa0256c6b75c6cb90ce7ee7e34961937537fbcR31-R76) [[3]](diffhunk://#diff-68c0eba203b38c0257ffc09dcdaa0256c6b75c6cb90ce7ee7e34961937537fbcL64-R121) [[4]](diffhunk://#diff-bfeabf1a0ee6de2e02ff7f44b794abe2a377c9cdffb80e360b1f5d847076f2f1R18)

### Build Metadata Changes

* Removed the `version` field from the `BuildMeta` record and all related logic, simplifying the metadata model. (`common/src/main/java/org/readutf/buildformat/common/meta/BuildMeta.java`, `common/src/main/java/org/readutf/buildformat/common/meta/impl/InMemoryMetaStore.java`, `sql/src/main/kotlin/org/readutf/buildformat/sql/ExposedMetaStore.kt`, [[1]](diffhunk://#diff-c79ce2e46e75a4b084942c9e031b16957e9cffac5188ec8d9bb148a43126ea9fL9) [[2]](diffhunk://#diff-b467dcf0e2c2b3fa5ed256fc8d1d87b8b75df43f92e8a043388115839239009fL22-R22) [[3]](diffhunk://#diff-3ee626e910bba526c86e2bcd1506716de79aacc6700684296f9294fa81ebd49fL47) [[4]](diffhunk://#diff-3ee626e910bba526c86e2bcd1506716de79aacc6700684296f9294fa81ebd49fL61) [[5]](diffhunk://#diff-3ee626e910bba526c86e2bcd1506716de79aacc6700684296f9294fa81ebd49fL98)

* Changed the `update` method in `BuildMetaStore` to return void instead of `BuildMeta`, updating all implementations accordingly. (`common/src/main/java/org/readutf/buildformat/common/meta/BuildMetaStore.java`, `common/src/main/java/org/readutf/buildformat/common/meta/impl/InMemoryMetaStore.java`, [[1]](diffhunk://#diff-40d1e352623d6e9f0102fc0ea516c00cfddfc1ed6703e0af87fc0d8b0fead4c9L16-R16) [[2]](diffhunk://#diff-b467dcf0e2c2b3fa5ed256fc8d1d87b8b75df43f92e8a043388115839239009fL33-L46)

### Test and File Renaming

* Renamed the test file for S3 build storage to reflect the new `BuildData` class and updated all related test logic. (`s3/src/test/java/org/readutf/buildformat/s3/S3BuildDataStoreTest.java`, [[1]](diffhunk://#diff-9d2d089425c8ccc178581ed0adfcd4e7a18998a47a43fa9dec81193e9b08d5a3L6-R6) [[2]](diffhunk://#diff-9d2d089425c8ccc178581ed0adfcd4e7a18998a47a43fa9dec81193e9b08d5a3R20-R22) [[3]](diffhunk://#diff-9d2d089425c8ccc178581ed0adfcd4e7a18998a47a43fa9dec81193e9b08d5a3L52-R58) [[4]](diffhunk://#diff-9d2d089425c8ccc178581ed0adfcd4e7a18998a47a43fa9dec81193e9b08d5a3L83-R89)

These changes collectively modernize the build format system, making it more extensible and robust for future features.